### PR TITLE
Add restructuredtext-lint into rules-lint repo

### DIFF
--- a/example/.aspect/cli/config.yaml
+++ b/example/.aspect/cli/config.yaml
@@ -7,6 +7,7 @@ lint:
     - //tools/lint:linters.bzl%pmd
     - //tools/lint:linters.bzl%stylelint
     - //tools/lint:linters.bzl%ruff
+    - //tools/lint:linters.bzl%rst_lint
     - //tools/lint:linters.bzl%vale
     - //tools/lint:linters.bzl%checkstyle
     - //tools/lint:linters.bzl%clang_tidy

--- a/example/requirements.in
+++ b/example/requirements.in
@@ -1,1 +1,2 @@
 flake8
+restructuredtext-lint==1.4.0

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    bazel run //:requirements.update
 #
+docutils==0.21.2 \
+    --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f \
+    --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
+    # via restructuredtext-lint
 flake8==6.1.0 \
     --hash=sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23 \
     --hash=sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5
@@ -20,3 +24,6 @@ pyflakes==3.1.0 \
     --hash=sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774 \
     --hash=sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
     # via flake8
+restructuredtext-lint==1.4.0 \
+    --hash=sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45
+    # via -r requirements.in

--- a/example/src/BUILD.bazel
+++ b/example/src/BUILD.bazel
@@ -25,6 +25,12 @@ filegroup(
     tags = ["markdown"],
 )
 
+filegroup(
+    name = "rst",
+    srcs = ["hello.rst"],
+    tags = ["restructuredtext"],
+)
+
 ts_project(
     name = "ts_dep",
     srcs = ["file-dep.ts"],

--- a/example/src/hello.rst
+++ b/example/src/hello.rst
@@ -1,0 +1,17 @@
+rst = """
+Some content.
+
+Hello World
+=======
+Some more content!
+"""
+errors = restructuredtext_lint.lint(rst, 'myfile.py')
+errors[0].line  # 5
+errors[0].source  # myfile.py
+errors[0].level  # 2
+errors[0].type  # WARNING
+errors[0].message  # Title underline too short.
+errors[0].full_message  # Title underline too short.
+                        #
+                        # Hello World
+                        # =======

--- a/example/tools/lint/BUILD.bazel
+++ b/example/tools/lint/BUILD.bazel
@@ -26,6 +26,13 @@ py_console_script_binary(
     pkg = "@pip//flake8:pkg",
 )
 
+# We can test that it works with:
+# bazel run :restructuredtext-lint -- --help
+py_console_script_binary(
+    name = "restructuredtext-lint",
+    pkg = "@pip//restructuredtext_lint:pkg",
+)
+
 eslint_bin.eslint_binary(name = "eslint")
 
 stylelint_bin.stylelint_binary(name = "stylelint")

--- a/example/tools/lint/linters.bzl
+++ b/example/tools/lint/linters.bzl
@@ -8,6 +8,7 @@ load("@aspect_rules_lint//lint:flake8.bzl", "lint_flake8_aspect")
 load("@aspect_rules_lint//lint:ktlint.bzl", "lint_ktlint_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@aspect_rules_lint//lint:pmd.bzl", "lint_pmd_aspect")
+load("@aspect_rules_lint//lint:rst_lint.bzl", "lint_rst_aspect")
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
 load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 load("@aspect_rules_lint//lint:stylelint.bzl", "lint_stylelint_aspect")
@@ -78,6 +79,10 @@ vale = lint_vale_aspect(
     binary = "@@//tools/lint:vale",
     config = "@@//:.vale.ini",
     styles = "@@//tools/lint:vale_styles",
+)
+
+rst_lint = lint_rst_aspect(
+    binary = "@@//tools/lint:restructuredtext-lint",
 )
 
 ktlint = lint_ktlint_aspect(

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -155,6 +155,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "rst_lint",
+    srcs = ["rst_lint.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//lint/private:lint_aspect"],
+)
+
+bzl_library(
     name = "pmd",
     srcs = ["pmd.bzl"],
     visibility = ["//visibility:public"],

--- a/lint/rst_lint.bzl
+++ b/lint/rst_lint.bzl
@@ -1,0 +1,108 @@
+"""API for declaring a rstlint aspect that visits py_library rules.
+
+Typical usage:
+
+First, fetch the rst-lint package via your standard requirements file and pip calls.
+
+Then, declare a binary target for it, typically in `tools/lint/BUILD.bazel`:
+
+```starlark
+load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
+py_console_script_binary(
+    name = "restructuredtext-lint",
+    pkg = "@pip//restructuredtext_lint:pkg",
+)
+```
+
+Finally, create the linter aspect, typically in `tools/lint/linters.bzl`:
+
+```starlark
+load("@aspect_rules_lint//lint:rst_lint.bzl", "lint_rst_aspect")
+
+restructuredtext_lint = lint_rst_aspect(
+    binary = "@@//tools/lint:restructuredtext-lint",
+)
+```
+"""
+
+load("//lint/private:lint_aspect.bzl", "LintOptionsInfo", "filter_srcs", "noop_lint_action", "output_files", "should_visit")
+
+_MNEMONIC = "AspectRulesLintRestructuredText"
+
+def rst_lint_action(ctx, executable, srcs, stdout, exit_code = None, options = []):
+    """Run restructuredtext-lint as an action under Bazel.
+
+    Based on https://github.com/twolfson/restructuredtext-lint
+
+    Args:
+        ctx: Bazel Rule or Aspect evaluation context
+        executable: label of the the restructuredtext-lint program
+        srcs: python files to be linted
+        stdout: output file containing stdout of restructuredtext-lint
+        exit_code: output file containing exit code of restructuredtext-lint
+            If None, then fail the build when restructuredtext-lint exits non-zero.
+        options: additional command-line options, see https://github.com/twolfson/restructuredtext-lint?tab=readme-ov-file#cli-utility
+    """
+    inputs = srcs
+    outputs = [stdout]
+
+    # Wire command-line options, see
+    # https://github.com/twolfson/restructuredtext-lint?tab=readme-ov-file#cli-utility
+    args = ctx.actions.args()
+    args.add_all(options)
+    args.add_all(srcs)
+    if exit_code:
+        command = "{rstlint} $@ >{stdout}; echo $? > " + exit_code.path
+        outputs.append(exit_code)
+    else:
+        # Create empty stdout file on success, as Bazel expects one
+        command = "{rstlint} $@ && touch {stdout}"
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = outputs,
+        tools = [executable],
+        command = command.format(rstlint = executable.path, stdout = stdout.path),
+        arguments = [args],
+        mnemonic = _MNEMONIC,
+        progress_message = "Linting %{label} with restructuredtext-lint",
+    )
+
+# buildifier: disable=function-docstring
+def _rst_lint_aspect_impl(target, ctx):
+    # for now we only support linter over filegroup
+    rule_kinds = []
+
+    if not should_visit(ctx.rule, rule_kinds, ctx.attr._filegroup_tags):
+        return []
+
+    outputs, info = output_files(_MNEMONIC, target, ctx)
+    files_to_lint = filter_srcs(ctx.rule)
+
+    if len(files_to_lint) == 0:
+        noop_lint_action(ctx, outputs)
+        return [info]
+
+    rst_lint_action(ctx, ctx.executable._rst_lint, files_to_lint, outputs.human.out, outputs.human.exit_code)
+    rst_lint_action(ctx, ctx.executable._rst_lint, files_to_lint, outputs.machine.out, outputs.machine.exit_code)
+    return [info]
+
+def lint_rst_aspect(binary, filegroup_tags = ["restructuredtext"]):
+    """A factory function to create a linter aspect."""
+    return aspect(
+        implementation = _rst_lint_aspect_impl,
+        attrs = {
+            "_options": attr.label(
+                default = "//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_rst_lint": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_filegroup_tags": attr.string_list(
+                default = filegroup_tags,
+            ),
+        },
+    )


### PR DESCRIPTION
Add linter for restructuredtext (.rst files).The linter is integrated based on the requirements and guidelines of this repository.